### PR TITLE
change the translation of 'Chinese translation'

### DIFF
--- a/README-ch.md
+++ b/README-ch.md
@@ -3,8 +3,6 @@
 # The Book of Shaders
 *by [Patricio Gonzalez Vivo](http://patriciogonzalezvivo.com/)*
 
-This is a gentle step-by-step guide through the abstract and complex universe of Fragment Shaders.
-
 这是一本关于 Fragment Shaders（片段着色器）的入门指南，它将一步一步地带你领略其中的纷繁与抽象。
 
 <div class="header">

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Thanks [Scott Murray](http://alignedleft.com/) for the inspiration and advice.
 
 Thanks [Kenichi Yoneda (Kynd)](https://twitter.com/kyndinfo) and [Sawako](https://twitter.com/sawakohome) for the [Japanese translation (日本語訳)](?lan=jp)
 
-Thanks [Tong Li](https://www.facebook.com/tong.lee.9484) and [Yi Zhang](https://www.facebook.com/archer.zetta?pnref=story) for the [Chinese translation (中国的翻译)](?lan=ch)
+Thanks [Tong Li](https://www.facebook.com/tong.lee.9484) and [Yi Zhang](https://www.facebook.com/archer.zetta?pnref=story) for the [Chinese translation (中文版)](?lan=ch)
 
 Thanks [Karim Naaji](http://karim.naaji.fr/) for contributing with support, good ideas and code.
 

--- a/chap-header.php
+++ b/chap-header.php
@@ -3,7 +3,7 @@
 	echo '
 	<div class="header">
 		<p><a href="http://thebookofshaders.com/">The Book of Shaders</a> by <a href="http://patriciogonzalezvivo.com">Patricio Gonzalez Vivo</a> </p>
-		<p><a href=".">English</a> - <a href="?lan=jp">日本語</a> - <a href="?lan=ch">中国的翻译</a> </p>
+		<p><a href=".">English</a> - <a href="?lan=jp">日本語</a> - <a href="?lan=ch">中文版</a> </p>
 	</div>
 	<hr>
 	';


### PR DESCRIPTION
It's better to call "Chinese translation" "中文版" than "中国的翻译".