### PR TITLE
Quintic interpolation moved to separate section

### DIFF
--- a/11/README.md
+++ b/11/README.md
@@ -152,6 +152,20 @@ For you to practice:
 
 ![Jackson Pollock - Number 14 gray (1948)](pollock.jpg)
 
+## Improved Noise
+
+An improvement by Perlin to his original non-simplex noise **Simplex Noise**, is the replacement of the cubic Hermite curve ( _f(x) = 3x^2-2x^3_ , which is identical to the [```smoothstep()```](.../glossary/?search=smoothstep) function) with a quintic interpolation curve ( _f(x) = 6x^5-15x^4+10x^3_ ). This makes both ends of the curve more "flat" so each border gracefully stitches with the next one. In other words, you get a more continuous transition between the cells. You can see this by uncommenting the second formula in the following graph example (or see the [two equations side by side here](https://www.desmos.com/calculator/2xvlk5xp8b)). 
+
+<div class="simpleFunction" data="
+// Cubic Hermite Curve.  Same as SmoothStep()
+y = x*x*(3.0-2.0*x);
+// Quintic interpolation curve
+//y = x*x*x*(x*(x*6.-15.)+10.);
+"></div>
+
+Note how the ends of the curve change. You can read more about this in [Ken's own words](http://mrl.nyu.edu/~perlin/paper445.pdf).
+
+
 ## Simplex Noise
 
 For Ken Perlin the success of his algorithm wasn't enough. He thought it could perform better. At Siggraph 2001 he presented the "simplex noise" in which he achieved the following improvements over the previous algorithm:
@@ -182,18 +196,7 @@ In the following code you can uncomment line 44 to see how the grid is skewed, a
 
 <div class="codeAndCanvas" data="simplex-grid.frag"></div>
 
-Another improvement introduced by Perlin with **Simplex Noise**, is the replacement of the Cubic Hermite Curve ( _f(x) = 3x^2-2x^3_ , which is identical to the [```smoothstep()```](.../glossary/?search=smoothstep) function) for a Quintic Hermite Curve ( _f(x) = 6x^5-15x^4+10x^3_ ). This makes both ends of the curve more "flat" so each border gracefully stiches with the next one. In other words you get a more continuous transition between the cells. You can see this by uncommenting the second formula in the following graph example (or see the [two equations side by side here](https://www.desmos.com/calculator/2xvlk5xp8b)). 
-
-<div class="simpleFunction" data="
-// Cubic Hermine Curve.  Same as SmoothStep()
-y = x*x*(3.0-2.0*x);
-// Quintic Hermine Curve
-//y = x*x*x*(x*(x*6.-15.)+10.);
-"></div>
-
-Note how the ends of the curve change. You can read more about this in [Ken's own words](http://mrl.nyu.edu/~perlin/paper445.pdf).
-
-All these improvements result in an algorithmic masterpiece known as **Simplex Noise**. The following is a GLSL implementation of this algorithm made by Ian McEwan (and presented in [this paper](http://webstaff.itn.liu.se/~stegu/jgt2012/article.pdf)) which is overcomplicated for educational purposes, but you will be happy to click on it and see that it is less cryptic than you might expect.
+All these improvements result in an algorithmic masterpiece known as **Simplex Noise**. The following is a GLSL implementation of this algorithm made by Ian McEwan and Stefan Gustavson (and presented in [this paper](http://webstaff.itn.liu.se/~stegu/jgt2012/article.pdf)) which is overcomplicated for educational purposes, but you will be happy to click on it and see that it is less cryptic than you might expect, and the code is short and fast.
 
 [ ![Ian McEwan of Ashima Arts - Simplex Noise](simplex-noise.png) ](../edit.php#11/2d-snoise-clear.frag)
 


### PR DESCRIPTION
Perlin's "Improved Noise" with quintic interpolation is separate from Simplex Noise, which does not even use interpolation. The contributions from each simplex corner are added, not blended. I created a separate section "Improved Noise" to hold the explanation of the quintic interpolation polynomial (which is not a Hermite polynomial, btw).