### PR TITLE
Fixed a small typo

### DIFF
--- a/01/README.md
+++ b/01/README.md
@@ -15,7 +15,7 @@ Shaders are also a set of instructions, but the instructions are excecuted all a
 
 To answer this, I present the wonders of *parallel processing*.
 
-Imagine the CPU of your computer as a big industrial pipe, and every task as something that passes through it - like a factory line. Some tasks are bigger than others, which means they require more time and energy to deal with. We say they require more processing power. Because of the architecture of computers the jobs are forced to run in a series; each job has to be finished one at a time. Modern computers usually have groups of four processors that work like these pipes, completing tasks one after another to keeping things running smoothly. Each pipe is also known as *thread*.
+Imagine the CPU of your computer as a big industrial pipe, and every task as something that passes through it - like a factory line. Some tasks are bigger than others, which means they require more time and energy to deal with. We say they require more processing power. Because of the architecture of computers the jobs are forced to run in a series; each job has to be finished one at a time. Modern computers usually have groups of four processors that work like these pipes, completing tasks one after another to keeping things running smoothly. Each pipe is also known as a *thread*.
 
 ![CPU](00.jpeg)
 


### PR DESCRIPTION
I made a small change to the last sentence of line 18:

```
Original:  "Each pipe is also known as *thread*."
Corrected: "Each pipe is also known as a *thread*."
                                       ^
```

It's also saying I made a change on line 48, but I didn't. The text there is the same as it was before.
¯\\\_(ツ)\_/¯