### PR TITLE
Use `st.x` to plot greyscale values along x

### DIFF
--- a/05/linear.frag
+++ b/05/linear.frag
@@ -7,9 +7,9 @@ uniform vec2 u_mouse;
 uniform float u_time;
 
 // Plot a line on Y using a value between 0.0-1.0
-float plot(vec2 st, float pct){
-  return  smoothstep( pct-0.02, pct, st.y) - 
-          smoothstep( pct, pct+0.02, st.y);
+float plot(float x, float y){
+  return  smoothstep( x-0.02, x, y) - 
+          smoothstep( x, x+0.02, y);
 }
 
 void main() {
@@ -18,8 +18,7 @@ void main() {
     vec3 color = vec3(st.x);
     
     // Plot a line
-    float y = st.x;
-    float pct = plot(st,y);
+    float pct = plot(st.x, st.y);
     color = (1.0-pct)*color+pct*vec3(0.0,1.0,0.0);
     
 	gl_FragColor = vec4(color,1.0);

--- a/05/linear.frag
+++ b/05/linear.frag
@@ -13,13 +13,12 @@ float plot(vec2 st, float pct){
 }
 
 void main() {
-	vec2 st = gl_FragCoord.xy/u_resolution;
+    vec2 st = gl_FragCoord.xy/u_resolution;
 
-    float y = st.x;
-
-    vec3 color = vec3(y);
+    vec3 color = vec3(st.x);
     
     // Plot a line
+    float y = st.x;
     float pct = plot(st,y);
     color = (1.0-pct)*color+pct*vec3(0.0,1.0,0.0);
     


### PR DESCRIPTION
Instead of the previous version, which was confusing because the variable `y` was used to determine the greyscale value of each column (x coordinate). This version moves the declaration of `y` down to the block in which it's used, the line plot.