### PR TITLE
Fix readme command for offline installing

### DIFF
--- a/appendix/00/README-de.md
+++ b/appendix/00/README-de.md
@@ -26,7 +26,7 @@ Hast Du alles beisammen, musst Du lediglich folgende Befehle aufrufen, um das *B
 cd ~
 git clone --recursive https://github.com/patriciogonzalezvivo/thebookofshaders.git
 cd thebookofshaders
-git submodule foreach git pull
+git submodule foreach git submodule init && git submodule update
 php -S localhost:8000
 ```
 

--- a/appendix/00/README-it.md
+++ b/appendix/00/README-it.md
@@ -9,7 +9,7 @@ Su **MacOSX** siate sicuri di avere installato [homebrew](http://brew.sh/) e qui
 ```bash
 brew update
 brew upgrade
-brew install git 
+brew install git
 ```
 
 Su **Raspberry Pi** è necessario fare:
@@ -26,7 +26,7 @@ Una volta che avete installato tutto, non vi resta che fare:
 cd ~
 git clone --recursive https://github.com/patriciogonzalezvivo/thebookofshaders.git
 cd thebookofshaders
-git submodule foreach git pull
+git submodule foreach git submodule init && git submodule update
 php -S localhost:8000
 ```
 

--- a/appendix/00/README.md
+++ b/appendix/00/README.md
@@ -9,7 +9,7 @@ In **MacOSX** be sure to have [homebrew](http://brew.sh/) installed and then on 
 ```bash
 brew update
 brew upgrade
-brew install git 
+brew install git
 ```
 
 On **Raspberry Pi** you need to do:
@@ -26,7 +26,7 @@ Once you have everything installed you just need to do:
 cd ~
 git clone --recursive https://github.com/patriciogonzalezvivo/thebookofshaders.git
 cd thebookofshaders
-git submodule foreach git pull
+git submodule foreach git submodule init && git submodule update
 php -S localhost:8000
 ```
 


### PR DESCRIPTION
Fixes #128 

[This SO thread](http://stackoverflow.com/questions/14927157/git-dependency-hell-submodule-pull-failing) provides a bit more context, but rather than running `git pull` within each submodule, I believe we should be running `git submodule init && git submodule update`. 

Doing so, in my case, resolved the error described in #128 and retrieved each submodule's content as expected.