### PR TITLE
Update Makefile with explicit Python version

### DIFF
--- a/makefile
+++ b/makefile
@@ -6,4 +6,4 @@ clean:
 	rm -rf book.*
 
 all:
-	python src/parseBook.py
+	python2 src/parseBook.py

--- a/src/makeThumbs.py
+++ b/src/makeThumbs.py
@@ -1,3 +1,5 @@
+#! /usr/bin/python2
+
 import glob, os, re, subprocess
 
 d='..'

--- a/src/parseBook.py
+++ b/src/parseBook.py
@@ -1,3 +1,4 @@
+#! /usr/bin/python2
 
 import os
 import os.path


### PR DESCRIPTION
Because on distributions like ArchLinux `/usr/bin/python` is a link to `python3`, so the script fails without virtualenv ...