### PR TITLE
replace iGlobalTime with iTime

### DIFF
--- a/03/README-ch.md
+++ b/03/README-ch.md
@@ -19,7 +19,7 @@ uniform float u_time;	  // 时间（加载后的秒数）
 ```glsl
 uniform vec3 iResolution;   // 视口分辨率（以像素计）
 uniform vec4 iMouse;        // 鼠标坐标 xy： 当前位置, zw： 点击位置
-uniform float iGlobalTime;  // shader 运行时间（以秒计）
+uniform float iTime;        // shader 运行时间（以秒计）
 ```
 
 好了说的足够多了，我们来看看实际操作中的 uniform 吧。在下面的代码中我们使用  ```u_time``` 加上一个 sin 函数，来展示图中红色的动态变化。

--- a/03/README-de.md
+++ b/03/README-de.md
@@ -19,7 +19,7 @@ Man kann sich Uniforms als eine Brücke zwischen der CPU und der GPU vorstellen.
 ```glsl
 uniform vec3 iResolution;   // Groesse der Malflaeche
 uniform vec4 iMouse;        // Mausposition
-uniform float iGlobalTime;  // Zeit seit dem Start
+uniform float iTime;        // Zeit seit dem Start
 ```
 
 Aber nun genug geredet. Lass uns die Uniforms in Aktion betrachten. Der folgende Programmcode nutzt ```u_time``` - die Anzahl der Sekunden, seitdem der Shader gestartet wurde - in Verbindung mit einer Sinus-Funktion, um die Intensität der Rotfärbung der Malfläche pulsieren zu lassen.

--- a/03/README-es.md
+++ b/03/README-es.md
@@ -19,7 +19,7 @@ Podemos imaginar que los uniforms son como pequeños puentes entra la CPU y la G
 ```glsl
 uniform vec3 iResolution;   // viewport resolution (in pixels)
 uniform vec4 iMouse;        // mouse pixel coords. xy: current, zw: click
-uniform float iGlobalTime;  // shader playback time (in seconds)
+uniform float iTime;        // shader playback time (in seconds)
 ```
 
 Ya hemos hablado mucho, vamos a ver los uniforms en acción. En el código siguiente usamos ```u_time``` - el número de segundos desde que el shader comenzó a ejecutarse - junto con una función del seno para animar en transición la cantidad de rojo en la pantalla.

--- a/03/README-fr.md
+++ b/03/README-fr.md
@@ -28,7 +28,7 @@ Par exemple [ShaderToy.com](https://www.shadertoy.com/) utilise les mêmes unifo
 ```glsl
 uniform vec3 iResolution;   // taille du canvas (en pixels)
 uniform vec4 iMouse;        // position de la souris. xy: courant, zw: au click
-uniform float iGlobalTime;  // temps écoulé depuis le lancement du shader (en secondes)
+uniform float iTime;        // temps écoulé depuis le lancement du shader (en secondes)
 ```
 
 Notez qu'ils utilisent un `i` au lieu de notre `u_`.

--- a/03/README-it.md
+++ b/03/README-it.md
@@ -19,7 +19,7 @@ uniform float u_time;	  // tempo in secondi da quando lo shader è iniziato
 ```glsl
 uniform vec3 iResolution;   // dimensione del Canvas (in pixels)
 uniform vec4 iMouse;        // posizione del mouse in pixels. xy: corrente, zw: click
-uniform float iGlobalTime;  // tempo (in secondi) da quando lo shader è iniziato
+uniform float iTime;        // tempo (in secondi) da quando lo shader è iniziato
 ```
 
 Ma ora basta chiacchiere, vediamo gli uniforms in azione. Nel seguente codice utilizziamo ```u_time``` - il numero di secondi da quando lo shader è iniziato - insieme ad una funzione seno per animare con una transizione la quantità di rosso sullo schermo.

--- a/03/README-jp.md
+++ b/03/README-jp.md
@@ -22,7 +22,7 @@ uniform変数はCPUとGPUの間の小さな架け橋だと考えることがで�
 ```glsl
 uniform vec3 iResolution;   // viewport resolution (in pixels)
 uniform vec4 iMouse;        // mouse pixel coords. xy: current, zw: click
-uniform float iGlobalTime;  // shader playback time (in seconds)
+uniform float iTime;        // shader playback time (in seconds)
 ```
 
 （訳注：uniform変数は開発者が自由に名前を決めることができ、上で挙げられている用途以外にも自由に使うことができます。C、JavascriptなどのCPUで走るプログラムからは、シェーダー側で決めた変数の名前を指定して値を渡すことができます）

--- a/03/README-kr.md
+++ b/03/README-kr.md
@@ -19,7 +19,7 @@ uniform float u_time;	  // Time in seconds since load
 ```glsl
 uniform vec3 iResolution;   // viewport resolution (in pixels)
 uniform vec4 iMouse;        // mouse pixel coords. xy: current, zw: click
-uniform float iGlobalTime;  // shader playback time (in seconds)
+uniform float iTime;        // shader playback time (in seconds)
 ```
 
 거두철미하고, 유니폼이 실제로 구현되는 부분을 보자. 아래 코드에서 ```u_time``` - 쉐이더가 구동된후 초 - 를 sine 함수에 인자로 넣어, 빨간색값을 조절하고 있는것을 볼수 있다.

--- a/03/README.md
+++ b/03/README.md
@@ -19,7 +19,7 @@ You can picture the uniforms like little bridges between the CPU and the GPU. Th
 ```glsl
 uniform vec3 iResolution;   // viewport resolution (in pixels)
 uniform vec4 iMouse;        // mouse pixel coords. xy: current, zw: click
-uniform float iGlobalTime;  // shader playback time (in seconds)
+uniform float iTime;        // shader playback time (in seconds)
 ```
 
 Enough talking, let's see the uniforms in action. In the following code we use `u_time` - the number of seconds since the shader started running - together with a sine function to animate the transition of the amount of red in the billboard.


### PR DESCRIPTION
As far as I can see shadertoy no longer has iGlobalTime uniform, it was replaced with iTime. Under the following link you can find current input uniforms: [https://www.shadertoy.com/howto](https://www.shadertoy.com/howto)