### PR TITLE
+ min-height on .codeAndCanvas

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -216,6 +216,7 @@ code {
 
 .codeAndCanvas {
     height:auto;
+    min-height:250px;
     clear:both;
 }
 


### PR DESCRIPTION
Text was wrapping oddly on the Hello World because the code and canvas block did not have a minimum height. This could be refactored further in favor of CSS Grids.