### PR TITLE
Removed an invalid character on the header

### DIFF
--- a/toc-header.php
+++ b/toc-header.php
@@ -1,3 +1,3 @@
 <div class="toc-header">
-    <p> <a href="?lan=jp">日本語</a> - <a href="?lan=ch">中文版</a> - <a href="?lan=kr">한국어</a> - <a href="?lan=es">Español</a> - <a href="?lan=pt">Portugues</a> - <a href="?lan=fr">Français</a> - <a href="?lan=it">Italiano</a> - <a href="?lan=de">Deutsch</a> - <a href="?lan=ru">Русский</a> - <a href=".">English</a></p>
+    <p> <a href="?lan=jp">日本語</a> - <a href="?lan=ch">中文版</a> - <a href="?lan=kr">한국어</a> - <a href="?lan=es">Español</a> - <a href="?lan=pt">Portugues</a> - <a href="?lan=fr">Français</a> - <a href="?lan=it">Italiano</a> - <a href="?lan=de">Deutsch</a> - <a href="?lan=ru">Русский</a> - <a href=".">English</a></p>
 </div>


### PR DESCRIPTION
It removes an invalid character from the toc-header.

Before:
![image](https://user-images.githubusercontent.com/48061245/54086969-df77cc80-4391-11e9-96d1-6849d96b8ceb.png)
After:
![image](https://user-images.githubusercontent.com/48061245/54086986-0a622080-4392-11e9-87b4-77accd0743cc.png)

Thanks.
