### PR TITLE
correct references to gradient noise

### DIFF
--- a/11/2d-gnoise.frag
+++ b/11/2d-gnoise.frag
@@ -12,8 +12,8 @@ vec2 random2(vec2 st){
     return -1.0 + 2.0*fract(sin(st)*43758.5453123);
 }
 
-// Value Noise by Inigo Quilez - iq/2013
-// https://www.shadertoy.com/view/lsf3WH
+// Gradient Noise by Inigo Quilez - iq/2013
+// https://www.shadertoy.com/view/XdXGW8
 float noise(vec2 st) {
     vec2 i = floor(st);
     vec2 f = fract(st);

--- a/11/circleWave-noise.frag
+++ b/11/circleWave-noise.frag
@@ -18,8 +18,8 @@ vec2 random2(vec2 st){
     return -1.0 + 2.0*fract(sin(st)*43758.5453123);
 }
 
-// Value Noise by Inigo Quilez - iq/2013
-// https://www.shadertoy.com/view/lsf3WH
+// Gradient Noise by Inigo Quilez - iq/2013
+// https://www.shadertoy.com/view/XdXGW8
 float noise(vec2 st) {
     vec2 i = floor(st);
     vec2 f = fract(st);

--- a/11/splatter.frag
+++ b/11/splatter.frag
@@ -12,8 +12,8 @@ vec2 random2(vec2 st){
     return -1.0 + 2.0*fract(sin(st)*43758.5453123);
 }
 
-// Value Noise by Inigo Quilez - iq/2013
-// https://www.shadertoy.com/view/lsf3WH
+// Gradient Noise by Inigo Quilez - iq/2013
+// https://www.shadertoy.com/view/XdXGW8
 float noise(vec2 st) {
     vec2 i = floor(st);
     vec2 f = fract(st);

--- a/11/tmp/warp-grid.frag
+++ b/11/tmp/warp-grid.frag
@@ -12,8 +12,8 @@ vec2 random2(vec2 st){
     return -1.0 + 2.0*fract(sin(st)*43758.5453123);
 }
 
-// Value Noise by Inigo Quilez - iq/2013
-// https://www.shadertoy.com/view/lsf3WH
+// Gradient Noise by Inigo Quilez - iq/2013
+// https://www.shadertoy.com/view/XdXGW8
 float noise(vec2 st) {
     vec2 i = floor(st);
     vec2 f = fract(st);


### PR DESCRIPTION
in four shaders a function that implements gradient noise was labeled as
value noise and linked to IQ's value noise example on shadertoy. this pr
labels that function as gradient noise and instead links to IQ's gradient noise
example on shadertoy.

this tripped me up as someone who was trying to learn the difference between the two