### PR TITLE
Fix breaking headline

### DIFF
--- a/appendix/01/README-de.md
+++ b/appendix/01/README-de.md
@@ -1,4 +1,4 @@
-## Wie kann ich die Beispielprogramme auf einem RaspberryPi ausführen?
+## Wie kann ich die Beispiele auf einem RaspberryPi ausführen?
 
 Vor wenigen Jahren konnte man noch nicht davon ausgehen, dass jedermann über einen Computer mit einer GPU verfügt. Heutzutage gilt das nicht mehr. Doch im Bereich von Schulen, Universitäten und anderen Weiterbildungseichrichtungen ist dies immer noch eine hohe Anforderung.
 


### PR DESCRIPTION
Since the `line-height` is set to 0px, this headline is breaking into two lines and overlaps with itself. Easiest fix is to just shorten the headline.

![image](https://user-images.githubusercontent.com/5489276/82422254-83730280-9a82-11ea-821e-61a2f78bfef3.png)