### PR TITLE
CSS: Remove an empty rule

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -106,10 +106,6 @@ img {
     color: #999;
 }
 
-.header .subtitle {
-
-}
-
 .header .subtitle a,
 .toc-header .subtitle a {
     font-size: 1.3em;


### PR DESCRIPTION
Reason: described functionality is used in line 2, not 1.

![image](https://user-images.githubusercontent.com/13063442/97084022-bd8d9500-161c-11eb-88b1-014835d8065f.png)
