### PR TITLE
Fixes #220 Improve legibility for small viewports (phones)

### DIFF
--- a/00/index.php
+++ b/00/index.php
@@ -20,13 +20,9 @@
 	$Parsedown = new Parsedown();
 	echo $Parsedown->text(file_get_contents($README.'.md'));
 
-	echo '
-	</div>
-	<hr>
-	<ul class="navigationBar" >
-		<li class="navigationBar" onclick="homePage()"> Home </li>
-		<li class="navigationBar" onclick="nextPage()">Next &gt; &gt;</li>
-	</ul>';
+	echo '</div>';
 
+	$show_previous = false;
+	$show_next = true;
 	include($path."/footer.php");
 ?>

--- a/01/index.php
+++ b/01/index.php
@@ -20,14 +20,9 @@
 	$Parsedown = new Parsedown();
 	echo $Parsedown->text(file_get_contents($README.'.md'));
 
-	echo '
-	</div>
-	<hr>
-	<ul class="navigationBar" >
-		<li class="navigationBar" onclick="previusPage()">&lt; &lt; Previous</li>
-		<li class="navigationBar" onclick="homePage()"> Home </li>
-		<li class="navigationBar" onclick="nextPage()">Next &gt; &gt;</li>
-	</ul>';
+	echo '</div>';
 
+	$show_previous = true;
+	$show_next = true;
 	include($path."/footer.php");
 ?>

--- a/02/index.php
+++ b/02/index.php
@@ -20,14 +20,9 @@
 	$Parsedown = new Parsedown();
 	echo $Parsedown->text(file_get_contents($README.'.md'));
 
-	echo '
-	</div>
-	<hr>
-	<ul class="navigationBar" >
-		<li class="navigationBar" onclick="previusPage()">&lt; &lt; Previous</li>
-		<li class="navigationBar" onclick="homePage()"> Home </li>
-		<li class="navigationBar" onclick="nextPage()">Next &gt; &gt;</li>
-	</ul>';
+	echo '</div>';
 
+	$show_previous = true;
+	$show_next = true;
 	include($path."/footer.php");
 ?>

--- a/03/index.php
+++ b/03/index.php
@@ -20,14 +20,9 @@
 	$Parsedown = new Parsedown();
 	echo $Parsedown->text(file_get_contents($README.'.md'));
 
-	echo '
-	</div>
-	<hr>
-	<ul class="navigationBar" >
-		<li class="navigationBar" onclick="previusPage()">&lt; &lt; Previous</li>
-		<li class="navigationBar" onclick="homePage()"> Home </li>
-		<li class="navigationBar" onclick="nextPage()">Next &gt; &gt;</li>
-	</ul>';
+	echo '</div>';
 
+	$show_previous = true;
+	$show_next = true;
 	include($path."/footer.php");
 ?>

--- a/04/index.php
+++ b/04/index.php
@@ -20,14 +20,9 @@
 	$Parsedown = new Parsedown();
 	echo $Parsedown->text(file_get_contents($README.'.md'));
 
-	echo '
-	</div>
-	<hr>
-	<ul class="navigationBar" >
-		<li class="navigationBar" onclick="previusPage()">&lt; &lt; Previous</li>
-		<li class="navigationBar" onclick="homePage()"> Home </li>
-		<li class="navigationBar" onclick="nextPage()">Next &gt; &gt;</li>
-	</ul>';
+	echo '</div>';
 
+	$show_previous = true;
+	$show_next = true;
 	include($path."/footer.php");
 ?>

--- a/05/index.php
+++ b/05/index.php
@@ -20,14 +20,9 @@
 	$Parsedown = new Parsedown();
 	echo $Parsedown->text(file_get_contents($README.'.md'));
 
-	echo '
-	</div>
-	<hr>
-	<ul class="navigationBar" >
-		<li class="navigationBar" onclick="previusPage()">&lt; &lt; Previous</li>
-		<li class="navigationBar" onclick="homePage()"> Home </li>
-		<li class="navigationBar" onclick="nextPage()">Next &gt; &gt;</li>
-	</ul>';
+	echo '</div>';
 
+	$show_previous = true;
+	$show_next = true;
 	include($path."/footer.php");
 ?>

--- a/06/index.php
+++ b/06/index.php
@@ -20,14 +20,9 @@
 	$Parsedown = new Parsedown();
 	echo $Parsedown->text(file_get_contents($README.'.md'));
 
-	echo '
-	</div>
-	<hr>
-	<ul class="navigationBar" >
-		<li class="navigationBar" onclick="previusPage()">&lt; &lt; Previous</li>
-		<li class="navigationBar" onclick="homePage()"> Home </li>
-		<li class="navigationBar" onclick="nextPage()">Next &gt; &gt;</li>
-	</ul>';
+	echo '</div>';
 
+	$show_previous = true;
+	$show_next = true;
 	include($path."/footer.php");
 ?>

--- a/07/index.php
+++ b/07/index.php
@@ -20,10 +20,10 @@
 	$Parsedown = new Parsedown();
 	echo $Parsedown->text(file_get_contents($README.'.md'));
 
-	echo '
-	<div id="product-component-1573172983507"></div>
+?>
+<div id="product-component-1573172983507"></div>
 <script type="text/javascript">
-/*<![CDATA[*/
+
 (function () {
   var scriptURL = "https://sdks.shopifycdn.com/buy-button/latest/buy-button-storefront.min.js";
   if (window.ShopifyBuy) {
@@ -272,15 +272,12 @@
     });
   }
 })();
-/*]]>*/
-</script>
-	</div>
-	<hr>
-	<ul class="navigationBar" >
-		<li class="navigationBar" onclick="previusPage()">&lt; &lt; Previous</li>
-		<li class="navigationBar" onclick="homePage()"> Home </li>
-		<li class="navigationBar" onclick="nextPage()">Next &gt; &gt;</li>
-	</ul>';
 
+</script>
+</div>
+
+<?php
+	$show_previous = true;
+	$show_next = true;
 	include($path."/footer.php");
 ?>

--- a/08/index.php
+++ b/08/index.php
@@ -20,14 +20,9 @@
 	$Parsedown = new Parsedown();
 	echo $Parsedown->text(file_get_contents($README.'.md'));
 
-	echo '
-	</div>
-	<hr>
-	<ul class="navigationBar" >
-		<li class="navigationBar" onclick="previusPage()">&lt; &lt; Previous</li>
-		<li class="navigationBar" onclick="homePage()"> Home </li>
-		<li class="navigationBar" onclick="nextPage()">Next &gt; &gt;</li>
-	</ul>';
+	echo '</div>';
 
+	$show_previous = true;
+	$show_next = true;
 	include($path."/footer.php");
 ?>

--- a/09/index.php
+++ b/09/index.php
@@ -20,14 +20,9 @@
 	$Parsedown = new Parsedown();
 	echo $Parsedown->text(file_get_contents($README.'.md'));
 
-	echo '
-	</div>
-	<hr>
-	<ul class="navigationBar" >
-		<li class="navigationBar" onclick="previusPage()">&lt; &lt; Previous</li>
-		<li class="navigationBar" onclick="homePage()"> Home </li>
-		<li class="navigationBar" onclick="nextPage()">Next &gt; &gt;</li>
-	</ul>';
+	echo '</div>';
 
+	$show_previous = true;
+	$show_next = true;
 	include($path."/footer.php");
 ?>

--- a/10/index.php
+++ b/10/index.php
@@ -20,15 +20,9 @@
 	$Parsedown = new Parsedown();
 	echo $Parsedown->text(file_get_contents($README.'.md'));
 
-	echo '
-	</div>
-	<hr>
-	<ul class="navigationBar" >
-		<li class="navigationBar" onclick="previusPage()">&lt; &lt; Previous</li>
-		<li class="navigationBar" onclick="homePage()"> Home </li>
-		<li class="navigationBar" onclick="nextPage()">Next &gt; &gt;</li>
+	echo '</div>';
 
-	</ul>';
-
+	$show_previous = true;
+	$show_next = true;
 	include($path."/footer.php");
 ?>

--- a/11/index.php
+++ b/11/index.php
@@ -20,14 +20,9 @@
 	$Parsedown = new Parsedown();
 	echo $Parsedown->text(file_get_contents($README.'.md'));
 
-	echo '
-	</div>
-	<hr>
-	<ul class="navigationBar" >
-		<li class="navigationBar" onclick="previusPage()">&lt; &lt; Previous</li>
-		<li class="navigationBar" onclick="homePage()"> Home </li>
-		<li class="navigationBar" onclick="nextPage()">Next &gt; &gt;</li>
-	</ul>';
+	echo '</div>';
 
+	$show_previous = true;
+	$show_next = true;
 	include($path."/footer.php");
 ?>

--- a/12/index.php
+++ b/12/index.php
@@ -20,14 +20,9 @@
 	$Parsedown = new Parsedown();
 	echo $Parsedown->text(file_get_contents($README.'.md'));
 
-	echo '
-	</div>
-	<hr>
-	<ul class="navigationBar" >
-		<li class="navigationBar" onclick="previusPage()">&lt; &lt; Previous</li>
-		<li class="navigationBar" onclick="homePage()"> Home </li>
-		<li class="navigationBar" onclick="nextPage()">Next &gt; &gt;</li>
-	</ul>';
+	echo '</div>';
 
+	$show_previous = true;
+	$show_next = true;
 	include($path."/footer.php");
 ?>

--- a/13/index.php
+++ b/13/index.php
@@ -20,15 +20,9 @@
 	$Parsedown = new Parsedown();
 	echo $Parsedown->text(file_get_contents($README.'.md'));
 
-	echo '
-	</div>
-	<hr>
-	<ul class="navigationBar" >
-		<li class="navigationBar" onclick="previusPage()">&lt; &lt; Previous</li>
-		<li class="navigationBar" onclick="homePage()"> Home </li>
-	</ul>';
+	echo '</div>';
 
+	$show_previous = true;
+	$show_next = true;
 	include($path."/footer.php");
 ?>
-
-<!-- <li class="navigationBar" onclick="nextPage()">Next &gt; &gt;</li> -->

--- a/14/index.php
+++ b/14/index.php
@@ -20,14 +20,9 @@
 	$Parsedown = new Parsedown();
 	echo $Parsedown->text(file_get_contents($README.'.md'));
 
-	echo '
-	</div>
-	<hr>
-	<ul class="navigationBar" >
-		<li class="navigationBar" onclick="previusPage()">&lt; &lt; Previous</li>
-		<li class="navigationBar" onclick="homePage()"> Home </li>
-		<li class="navigationBar" onclick="nextPage()">Next &gt; &gt;</li>
-	</ul>';
+	echo '</div>';
 
+	$show_previous = true;
+	$show_next = true;
 	include($path."/footer.php");
 ?>

--- a/15/index.php
+++ b/15/index.php
@@ -19,14 +19,9 @@
 	$Parsedown = new Parsedown();
 	echo $Parsedown->text(file_get_contents($README.'.md'));
 
-	echo '
-	</div>
-	<hr>
-	<ul class="navigationBar" >
-		<li class="navigationBar" onclick="previusPage()">&lt; &lt; Previous</li>
-		<li class="navigationBar" onclick="homePage()"> Home </li>
-		<li class="navigationBar" onclick="nextPage()">Next &gt; &gt;</li>
-	</ul>';
+	echo '</div>';
 
+	$show_previous = true;
+	$show_next = true;
 	include($path."/footer.php");
 ?>

--- a/16/index.php
+++ b/16/index.php
@@ -19,14 +19,9 @@
 	$Parsedown = new Parsedown();
 	echo $Parsedown->text(file_get_contents($README.'.md'));
 
-	echo '
-	</div>
-	<hr>
-	<ul class="navigationBar" >
-		<li class="navigationBar" onclick="previusPage()">&lt; &lt; Previous</li>
-		<li class="navigationBar" onclick="homePage()"> Home </li>
-		<li class="navigationBar" onclick="nextPage()">Next &gt; &gt;</li>
-	</ul>';
+	echo '</div>';
 
+	$show_previous = true;
+	$show_next = true;
 	include($path."/footer.php");
 ?>

--- a/17/index.php
+++ b/17/index.php
@@ -19,14 +19,9 @@
 	$Parsedown = new Parsedown();
 	echo $Parsedown->text(file_get_contents($README.'.md'));
 
-	echo '
-	</div>
-	<hr>
-	<ul class="navigationBar" >
-		<li class="navigationBar" onclick="previusPage()">&lt; &lt; Previous</li>
-		<li class="navigationBar" onclick="homePage()"> Home </li>
-		<li class="navigationBar" onclick="nextPage()">Next &gt; &gt;</li>
-	</ul>';
+	echo '</div>';
 
+	$show_previous = true;
+	$show_next = true;
 	include($path."/footer.php");
 ?>

--- a/18/index.php
+++ b/18/index.php
@@ -19,14 +19,9 @@
 	$Parsedown = new Parsedown();
 	echo $Parsedown->text(file_get_contents($README.'.md'));
 
-	echo '
-	</div>
-	<hr>
-	<ul class="navigationBar" >
-		<li class="navigationBar" onclick="previusPage()">&lt; &lt; Previous</li>
-		<li class="navigationBar" onclick="homePage()"> Home </li>
-		<li class="navigationBar" onclick="nextPage()">Next &gt; &gt;</li>
-	</ul>';
+	echo '</div>';
 
+	$show_previous = true;
+	$show_next = true;
 	include($path."/footer.php");
 ?>

--- a/appendix/00/index.php
+++ b/appendix/00/index.php
@@ -19,14 +19,9 @@
 	$Parsedown = new Parsedown();
 	echo $Parsedown->text(file_get_contents($README.'.md'));
 
-	echo '
-	</div>
-	<hr>
-	<ul class="navigationBar" >
-		<li class="navigationBar" onclick="previusPage()">&lt; &lt; Previous</li>
-		<li class="navigationBar" onclick="homePage()"> Home </li>
-		<li class="navigationBar" onclick="nextPage()">Next &gt; &gt;</li>
-	</ul>';
+	echo '</div>';
 
+	$show_previous = true;
+	$show_next = true;
 	include($path."/footer.php");
 ?>

--- a/appendix/01/index.php
+++ b/appendix/01/index.php
@@ -19,14 +19,9 @@
 	$Parsedown = new Parsedown();
 	echo $Parsedown->text(file_get_contents($README.'.md'));
 
-	echo '
-	</div>
-	<hr>
-	<ul class="navigationBar" >
-		<li class="navigationBar" onclick="previusPage()">&lt; &lt; Previous</li>
-		<li class="navigationBar" onclick="homePage()"> Home </li>
-		<li class="navigationBar" onclick="nextPage()">Next &gt; &gt;</li>
-	</ul>';
+	echo '</div>';
 
+	$show_previous = true;
+	$show_next = true;
 	include($path."/footer.php");
 ?>

--- a/appendix/02/index.php
+++ b/appendix/02/index.php
@@ -19,14 +19,9 @@
 	$Parsedown = new Parsedown();
 	echo $Parsedown->text(file_get_contents($README.'.md'));
 
-	echo '
-	</div>
-	<hr>
-	<ul class="navigationBar" >
-		<li class="navigationBar" onclick="previusPage()">&lt; &lt; Previous</li>
-		<li class="navigationBar" onclick="homePage()"> Home </li>
-		<li class="navigationBar" onclick="nextPage()">Next &gt; &gt;</li>
-	</ul>';
+	echo '</div>';
 
+	$show_previous = true;
+	$show_next = true;
 	include($path."/footer.php");
 ?>

--- a/appendix/03/index.php
+++ b/appendix/03/index.php
@@ -19,14 +19,9 @@
 	$Parsedown = new Parsedown();
 	echo $Parsedown->text(file_get_contents($README.'.md'));
 
-	echo '
-	</div>
-	<hr>
-	<ul class="navigationBar" >
-		<li class="navigationBar" onclick="previusPage()">&lt; &lt; Previous</li>
-		<li class="navigationBar" onclick="homePage()"> Home </li>
-		<li class="navigationBar" onclick="nextPage()">Next &gt; &gt;</li>
-	</ul>';
+	echo '</div>';
 
+	$show_previous = true;
+	$show_next = true;
 	include($path."/footer.php");
 ?>

--- a/appendix/04/index.php
+++ b/appendix/04/index.php
@@ -19,14 +19,9 @@
 	$Parsedown = new Parsedown();
 	echo $Parsedown->text(file_get_contents($README.'.md'));
 
-	echo '
-	</div>
-	<hr>
-	<ul class="navigationBar" >
-		<li class="navigationBar" onclick="previusPage()">&lt; &lt; Previous</li>
-		<li class="navigationBar" onclick="homePage()"> Home </li>
-		<li class="navigationBar" onclick="nextPage()">Next &gt; &gt;</li>
-	</ul>';
+	echo '</div>';
 
+	$show_previous = true;
+	$show_next = true;
 	include($path."/footer.php");
 ?>

--- a/appendix/05/index.php
+++ b/appendix/05/index.php
@@ -19,14 +19,9 @@
 	$Parsedown = new Parsedown();
 	echo $Parsedown->text(file_get_contents($README.'.md'));
 
-	echo '
-	</div>
-	<hr>
-	<ul class="navigationBar" >
-		<li class="navigationBar" onclick="previusPage()">&lt; &lt; Previous</li>
-		<li class="navigationBar" onclick="homePage()"> Home </li>
-		<li class="navigationBar" onclick="nextPage()">Next &gt; &gt;</li>
-	</ul>';
+	echo '</div>';
 
+	$show_previous = true;
+	$show_next = true;
 	include($path."/footer.php");
 ?>

--- a/appendix/06/index.php
+++ b/appendix/06/index.php
@@ -19,14 +19,9 @@
 	$Parsedown = new Parsedown();
 	echo $Parsedown->text(file_get_contents($README.'.md'));
 
-	echo '
-	</div>
-	<hr>
-	<ul class="navigationBar" >
-		<li class="navigationBar" onclick="previusPage()">&lt; &lt; Previous</li>
-		<li class="navigationBar" onclick="homePage()"> Home </li>
-		<li class="navigationBar" onclick="nextPage()">Next &gt; &gt;</li>
-	</ul>';
+	echo '</div>';
 
+	$show_previous = true;
+	$show_next = true;
 	include($path."/footer.php");
 ?>

--- a/appendix/index.php
+++ b/appendix/index.php
@@ -19,14 +19,9 @@
 	$Parsedown = new Parsedown();
 	echo $Parsedown->text(file_get_contents($README.'.md'));
 
-	echo '
-	</div>
-	<hr>
-	<ul class="navigationBar" >
-		<li class="navigationBar" onclick="previusPage()">&lt; &lt; Previous</li>
-		<li class="navigationBar" onclick="homePage()"> Home </li>
-		<li class="navigationBar" onclick="nextPage()">Next &gt; &gt;</li>
-	</ul>';
+	echo '</div>';
 
+	$show_previous = true;
+	$show_next = true;
 	include($path."/footer.php");
 ?>

--- a/css/style.css
+++ b/css/style.css
@@ -71,14 +71,14 @@ img {
     display: block;
     margin-left: auto;
     margin-right: auto;
-    max-width: 520px;
+    max-width: 100%;
 }
 
 .imgcontainer {
     display: block;
     margin-left: auto;
     margin-right: auto;
-    max-width: 520px;
+    max-width: 60%;
 }
 
 .caption {
@@ -237,7 +237,7 @@ code {
 .simpleFunction {
     margin-left: auto;
     margin-right: auto;
-    max-width: 700px;
+    max-width: 100%;
 
 }
 
@@ -253,7 +253,7 @@ code {
     display: block;
     margin-left: auto;
     margin-right: auto;
-    max-width: 700px;
+    max-width: 100%;
 }
 
 .cm-s-default .cm-variable-3 {

--- a/css/style.css
+++ b/css/style.css
@@ -56,7 +56,7 @@ h3 {
 }
 
 #content {
-    width: 800px;
+    max-width: 800px;
     margin-left: auto;
     margin-right: auto;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -135,17 +135,21 @@ footer {
 }
 
 .navigationBar {
-    text-align: center;
-    cursor: pointer;
-    cursor: hand;
+    width:100%;
+    display:flex;
+    flex-direction:row;
+    padding:0;
 }
 
-li.navigationBar {
+.navigationBar li {
+    flex:1;
     list-style-type: none;
     display: inline;
-    margin: 20px;
+    word-break:keep-all;
+    margin:20px;
     font-size: 24px;
     font-style: italic;
+    text-align:center;
 }
 
 

--- a/css/style.css
+++ b/css/style.css
@@ -10,8 +10,7 @@ body {
     padding: 0;
     color: #222;
     margin-bottom: 60px;
-    margin-left: 60px;
-	margin-right: 60px;
+    margin: 10vmin 5vw;
 }
 
 h1 {
@@ -92,7 +91,6 @@ img {
 .header {
     font-size: 16px;
     line-height: 16px;
-    margin-top: 60px;
     text-align: right;
     color: #999;
 }

--- a/footer.php
+++ b/footer.php
@@ -1,6 +1,14 @@
-
-
         <footer>
+            <hr>
+            <ul class="navigationBar">
+            <?php if($show_previous): ?>
+                <li class="navigationBar" onclick="previusPage()">&lt;&nbsp;&lt;&nbsp;Previous</li>
+            <?php endif; ?>
+                <li class="navigationBar" onclick="homePage()">Home</li>
+            <?php if($show_next): ?>
+                <li class="navigationBar" onclick="nextPage()">Next&nbsp;&gt;&nbsp;&gt;</li>
+            <?php endif; ?>
+            </ul>
             <p> Copyright 2015 <a href="http://www.patriciogonzalezvivo.com" target="_blank">Patricio Gonzalez Vivo</a> </p>
         </footer>
 <?php

--- a/header.php
+++ b/header.php
@@ -6,12 +6,12 @@
     echo '
         <title>The Book of Shaders'.$subtitle.'</title>';
 ?>
-
+        
         <link href="/favicon.gif" rel="shortcut icon"/>
         <meta name="keywords" content="shader,openGL,WebGL,GLSL,book,procedural,generative" />
         <meta name="description" content="Gentle step-by-step guide through the abstract and complex universe of Fragment Shaders."/>
 
-        <!— Open Graph data —>
+        <!-- Open Graph data -->
         <meta property="og:type" content="article"/>
         <meta property="og:title" content="The Book of Shaders"/>
         <meta property="og:site_name" content="The Book of Shaders"/>
@@ -23,7 +23,7 @@
         <meta property="og:image:height" content="500" />
 
 
-        <!— Twitter Card—>
+        <!-- Twitter Card-->
         <meta name="twitter:card" content="image">
         <meta name="twitter:site" content="@bookofshaders">
         <meta name="twitter:creator" content="@patriciogv">
@@ -35,7 +35,7 @@
         <meta name="twitter:image:height" content="500">
 
 
-        <link href="/favicon.gif" rel="shortcut icon"/>
+        <meta name="viewport" content="width=device-width, initial-scale=1">
 
         <!-- Highlight -->
 <?php


### PR DESCRIPTION
Limits content to not be wider than the viewport, useful for reading in a side-bar or on a small screen like a phone. This PR was able to solve the basics of text content and navigation but there's still work to be done for the code editor sizing its associated <canvas> which forces code to wrap even if it means one character per line (pretty illegible!) I'm still working on it. This is a PR to make it visible that I started working on it.

<img width="404" alt="iPad screenshot" src="https://user-images.githubusercontent.com/1120619/97456046-db097a00-190e-11eb-95ad-a83a548abacb.png">

<img width="310" alt="Google Pixel 2 screenshot" src="https://user-images.githubusercontent.com/1120619/97456066-de046a80-190e-11eb-86b5-ed9b9c1abfd1.png">
