### PR TITLE
Updated print guide instruction for homebrew cask

### DIFF
--- a/appendix/02/README-id.md
+++ b/appendix/02/README-id.md
@@ -28,7 +28,7 @@ Pada **MacOSX**:
 Unduh dan Pasang MacTeX dengan:
 
 ```bash
-brew cask install mactex-no-gui
+brew install --cask mactex-no-gui
 ```
 
 Kemudian pasang [Pandoc](http://johnmacfarlane.net/pandoc/) dan Python 3 dengan:

--- a/appendix/02/README-vi.md
+++ b/appendix/02/README-vi.md
@@ -29,7 +29,7 @@ Trên **MacOSX**:
 Tải và cài đặt MacTeX bằng lệnh:
 
 ```bash
-brew cask install mactex-no-gui
+brew install --cask mactex-no-gui
 ```
 
 sau đó cài thêm [Pandoc](http://johnmacfarlane.net/pandoc/) và Python 2 bằng lệnh:

--- a/appendix/02/README.md
+++ b/appendix/02/README.md
@@ -30,7 +30,7 @@ In **MacOSX**:
 Download and Install MacTeX by:
 
 ```bash
-brew cask install mactex-no-gui
+brew install --cask mactex-no-gui
 ```
 
 and then install [Pandoc](http://johnmacfarlane.net/pandoc/) and Python 3 by:


### PR DESCRIPTION
Today I tried to get pdf version of The book of shaders. And was following the steps mention on readme.md file. I got stuck at one place. [Apparently brew no longer support `brew cask`](https://github.com/Homebrew/discussions/discussions/340#discussioncomment-232364). I have updated to the latest command that worked for me. 