### PR TITLE
fix `undefined array key "lan"` error

### DIFF
--- a/header.php
+++ b/header.php
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <?php
     $html_attributes = "";
-    if ($_GET['lan'] == "fa") {
+    if (!empty($_GET['lan']) && $_GET['lan'] == "fa") {
         $html_attributes = 'dir="rtl" lang="fa"';
     }
     echo '


### PR DESCRIPTION
was getting the following error from a clean build using php 8.1.2:

```
"Warning: Undefined array key "lan" in ~/thebookofshaders/header.php on line 4"
```

Was going to use `isset` but it seems like a banged `!empty` is used elsewhere. am not a php dev so will defer to anyone who feels more confident.