### PR TITLE
Create a github action to build and release the book

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,38 @@
+name: Build Book
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    env:
+      DISPLAY: ':99.0'
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set tag release as environment variable
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      - name: Step 1 - Install required APT packages
+        run: |
+            sudo add-apt-repository ppa:patriciogv/glslviewer-ppa
+            sudo apt-get update
+            # Setup the X11
+            sudo apt-get install libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 x11-utils
+            /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1920x1200x24 -ac +extension GLX
+            sudo apt-get install glslviewer texlive-xetex pandoc python2.7
+      - name: Step 2 - Build books
+        run: make all
+      - name: Step 3 - Append version to book files
+        run: |
+            mkdir release
+            mv book.pdf release/book-$RELEASE_VERSION.pdf
+            mv book.epub release/book-$RELEASE_VERSION.epub
+            mv book.tex release/book-$RELEASE_VERSION.tex
+      - name: Step 4 - Release books
+        uses: fnkr/github-action-ghr@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          GHR_PATH: release/
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHR_REPLACE: true


### PR DESCRIPTION
HI @patriciogonzalezvivo,

Thanks for your great work. In order for your users to get EPUB / PDF and TEX versions of your book without the need to clone the repo, I created a github action that do it for them. 

When you'll push a tag version (e.g. `v1.0.0`, for example), the three book formats will be built and pushed to release. You can see the consequence on my forked repo.

The release artifacts are there https://github.com/sroucheray/thebookofshaders/releases
The action that built it is here https://github.com/sroucheray/thebookofshaders/actions/runs/2840310688

Hope you'll find it useful.

Cheers,

Stephane 