### PR TITLE
Update brew install cask command

### DIFF
--- a/appendix/02/README.md
+++ b/appendix/02/README.md
@@ -30,7 +30,7 @@ In **MacOSX**:
 Download and Install MacTeX by:
 
 ```bash
-brew cask install mactex-no-gui
+brew install --cask mactex-no-gui
 ```
 
 and then install [Pandoc](http://johnmacfarlane.net/pandoc/) and Python 3 by:


### PR DESCRIPTION
From brew:

> Error: `brew cask` is no longer a `brew` command. Use `brew <command> --cask` instead.