### PR TITLE
Polish translation - fixes (acknowledgment, header, linking to polish articles)

### DIFF
--- a/README-pl.md
+++ b/README-pl.md
@@ -11,26 +11,26 @@
 
 ## Spis treści
 
-* [O książce](00/)
+* [O książce](00/?lan=pl)
 
 * Wprowadzenie
-    * [Czym jest shader?](01/)
-    * ["Witaj świecie!"](02/)
-    * [Uniformy](03/)
-	* [Uruchomienie shaderu](04/)
+    * [Czym jest shader?](01/?lan=pl)
+    * ["Witaj świecie!"](02/?lan=pl)
+    * [Uniformy](03/?lan=pl)
+	* [Uruchomienie shaderu](04/?lan=pl)
 
 * Rysowanie algorytmiczne
-    * [Shaping functions](05/)
-    * [Kolory](06/)
-    * [Kształty](07/)
-    * [Macierze](08/)
-    * [Wzorce](09/)
+    * [Shaping functions](05/?lan=pl)
+    * [Kolory](06/?lan=pl)
+    * [Kształty](07/?lan=pl)
+    * [Macierze](08/?lan=pl)
+    * [Wzorce](09/?lan=pl)
 
 * Design generatywny
-    * [Random](10/)
-    * [Noise](11/)
-    * [Cellular noise](12/)
-    * [Fractal Brownian Motion](13/)
+    * [Random](10/?lan=pl)
+    * [Noise](11/?lan=pl)
+    * [Cellular noise](12/?lan=pl)
+    * [Fractal Brownian Motion](13/?lan=pl)
     * Fraktale
 
 * Image processing
@@ -55,16 +55,16 @@
     * Environmental-maps (spherical and cube)
     * Reflect and refract
 
-* [Dodatek:](appendix/) Inne sposoby korzystania z tej książki
-	* [Jak mogę korzystać z tej książki offline?](appendix/00/)
-	* [Jak uruchomić przykłady na Raspberry Pi?](appendix/01/)
-	* [Jak wydrukować tę książkę?](appendix/02/)
-    * [Jak mogę pomóc?](appendix/03/)
-    * [Wprowadzenie dla biegłych w JavaScript](appendix/04/) by [Nicolas Barradeau](http://www.barradeau.com/)
+* [Dodatek:](appendix/?lan=pl) Inne sposoby korzystania z tej książki
+	* [Jak mogę korzystać z tej książki offline?](appendix/00/?lan=pl)
+	* [Jak uruchomić przykłady na Raspberry Pi?](appendix/01/?lan=pl)
+	* [Jak wydrukować tę książkę?](appendix/02/?lan=pl)
+    * [Jak mogę pomóc?](appendix/03/?lan=pl)
+    * [Wprowadzenie dla biegłych w JavaScript](appendix/04/?lan=pl) by [Nicolas Barradeau](http://www.barradeau.com/)
 
-* [Galeria przykładów](examples/)
+* [Galeria przykładów](examples/?lan=pl)
 
-* [Glosariusz](glossary/)
+* [Glosariusz](glossary/?lan=pl)
 
 ## O autorach
 

--- a/README-pl.md
+++ b/README-pl.md
@@ -104,6 +104,8 @@ Podziękowania dla [Sergey Karchevsky](https://www.facebook.com/sergey.karchevsk
 
 Podziękowania dla [Vu Phuong Hoang](https://www.facebook.com/vuphuonghoang88) za wietnamskie [tłumaczenie (Tiếng Việt)](?lan=vi)
 
+Podziękowania dla [Wojciecha Pachowiaka](https://github.com/WojtekPachowiak) za polskie [tłumaczenie (polski)](?lan=pl)
+
 Podziękowania dla [Andy Stanton](https://andy.stanton.is/) za naprawę i usprawnienie funkcji [eksportu pdf/epub ](https://thebookofshaders.com/appendix/02/)
 
 Podziękowania dla każdego, kto [współtworzy](https://github.com/patriciogonzalezvivo/thebookofshaders/graphs/contributors) ten projekt poprzez swoje rady, korekty lub finansowe wsparcie.

--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ Thanks [Sergey Karchevsky](https://www.facebook.com/sergey.karchevsky.3) for the
 
 Thanks [Vu Phuong Hoang](https://www.facebook.com/vuphuonghoang88) for the Vietnamese [translation (Tiếng Việt)](?lan=vi)
 
+Thanks [Wojciech Pachowiak](https://github.com/WojtekPachowiak) for the Polish [translation (polski)](?lan=pl)
+
 Thanks [Andy Stanton](https://andy.stanton.is/) for fixing and improving [the pdf/epub export pipeline](https://thebookofshaders.com/appendix/02/)
 
 Thanks to everyone who has believed in this project and [contributed with fixes](https://github.com/patriciogonzalezvivo/thebookofshaders/graphs/contributors) or donations.

--- a/chap-header.php
+++ b/chap-header.php
@@ -1,6 +1,6 @@
 
     <div class="header">
         <p class="subtitle"><a href="https://thebookofshaders.com/">The Book of Shaders</a> by <a href="http://patriciogonzalezvivo.com">Patricio Gonzalez Vivo</a> & <a href="http://jenlowe.net">Jen Lowe</a> </p>
-        <p>  <a href="?lan=id">Bahasa Indonesia</a> - <a href="?lan=vi">Tiếng Việt</a> - <a href="?lan=jp">日本語</a> - <a href="?lan=ch">中文版</a> - <a href="?lan=kr">한국어</a> - <a href="?lan=es">Español</a> - <a href="?lan=pt">Portugues</a> - <a href="?lan=fr">Français</a> - <a href="?lan=it">Italiano</a> - <a href="?lan=de">Deutsch</a> - <a href="?lan=ru">Русский</a> - <a href=".">English</a></p>
+        <p>  <a href="?lan=id">Bahasa Indonesia</a> - <a href="?lan=vi">Tiếng Việt</a> - <a href="?lan=jp">日本語</a> - <a href="?lan=ch">中文版</a> - <a href="?lan=kr">한국어</a> - <a href="?lan=es">Español</a> - <a href="?lan=pt">Portugues</a> - <a href="?lan=fr">Français</a> - <a href="?lan=it">Italiano</a> - <a href="?lan=de">Deutsch</a> - <a href="?lan=ru">Русский</a> - <a href="?lan=pl">Polski</a> - <a href=".">English</a></p>
     </div>
     <hr>

--- a/toc-header.php
+++ b/toc-header.php
@@ -1,3 +1,3 @@
 <div class="toc-header">
-    <p> <a href="?lan=id">Bahasa Indonesia</a> - <a href="?lan=vi"> Tiếng Việt</a> - <a href="?lan=jp">日本語</a> - <a href="?lan=ch">中文版</a> - <a href="?lan=kr">한국어</a> - <a href="?lan=es">Español</a> - <a href="?lan=pt">Portugues</a> - <a href="?lan=fr">Français</a> - <a href="?lan=it">Italiano</a> - <a href="?lan=de">Deutsch</a> - <a href="?lan=ru">Русский</a> - <a href=".">English</a></p>
+    <p> <a href="?lan=id">Bahasa Indonesia</a> - <a href="?lan=vi"> Tiếng Việt</a> - <a href="?lan=jp">日本語</a> - <a href="?lan=ch">中文版</a> - <a href="?lan=kr">한국어</a> - <a href="?lan=es">Español</a> - <a href="?lan=pt">Portugues</a> - <a href="?lan=fr">Français</a> - <a href="?lan=it">Italiano</a> - <a href="?lan=de">Deutsch</a> - <a href="?lan=ru">Русский</a> - <a href="?lan=pl">Polski</a> - <a href=".">English</a></p>
 </div>


### PR DESCRIPTION
As in the title:
- I've added acknowledgment for Polish translation, 
- updated the header so the link to switch to Polish version is present
- in ToC, when clicking the article links, the user is redirected to polish version instead of the default english one 