### PR TITLE
Fixed a typo in the glossary

### DIFF
--- a/glossary/README.md
+++ b/glossary/README.md
@@ -100,7 +100,7 @@
 [dot()](./?search=dot)
 [cross()](./?search=cross)
 [normalize()](./?search=normalize)
-[facefoward()](./?search=facefoward)
+[faceforward()](./?search=faceforward)
 [reflect()](./?search=reflect)
 [refract()](./?search=refract)
 


### PR DESCRIPTION
The `faceforward` function was missing its first `r`, leading to an empty page