### PR TITLE
Theme: Prevent flicker on first load

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -3,6 +3,12 @@
         <footer>
             <p> Copyright 2015 <a href="http://www.patriciogonzalezvivo.com" target="_blank">Patricio Gonzalez Vivo</a> </p>
         </footer>
+
+        <script type="text/javascript">
+            // Setting the theme immediately inside the inline script prevents flicker
+            document.body.dataset.theme = localStorage.getItem('theme') || 'light';
+        </script>
+
 <?php
     echo '
         <script type="text/javascript" src="'.$path.'/src/main.js" defer></script>';


### PR DESCRIPTION
This small fix sets the theme earlier, which prevents flicker when it changes from light to dark too abruptly