### PR TITLE
Fix misleading comment in shapes example.

### DIFF
--- a/07/shapes.frag
+++ b/07/shapes.frag
@@ -24,8 +24,10 @@ void main(){
   // Number of sides of your shape
   int N = 3;
 
-  // Angle and radius from the current pixel
+  // Angle from the current pixel
   float a = atan(st.x,st.y)+PI;
+
+  // Angular spacing between vertices of shape (in radians)
   float r = TWO_PI/float(N);
 
   // Shaping function that modulate the distance

--- a/07/shapes.frag
+++ b/07/shapes.frag
@@ -27,7 +27,7 @@ void main(){
   // Angle from the current pixel
   float a = atan(st.x,st.y)+PI;
 
-  // Angular spacing between vertices of shape (in radians)
+  // Angular spacing between vertices of shape
   float r = TWO_PI/float(N);
 
   // Shaping function that modulate the distance


### PR DESCRIPTION
Labeling 'r' as radius is misleading when it is actually the number of radians representing some segment of the circle for a triangle edge.

Feel free to adjust/rewrite the new comments!

Generally, I think this could afford to have even more comments / more aptly named variables, but this is at least removing an incorrect statement.

Thanks!