### PR TITLE
Fix issues in Chinese translation

### DIFF
--- a/00/README-ch.md
+++ b/00/README-ch.md
@@ -42,10 +42,10 @@ Fragment shaders（片段着色器）可以让你控制像素在屏幕上的快�
 
 此外，基于你有的条件或需求你可以：
 
-* [制作一个离线版的本书](https://thebookofshaders.com/appendix/)
+* [制作一个离线版的本书](https://thebookofshaders.com/appendix/00/?lan=ch)
 
-* [用树莓派而不是浏览器来运行书中示例](https://thebookofshaders.com/appendix/)
+* [用树莓派而不是浏览器来运行书中示例](https://thebookofshaders.com/appendix/01/?lan=ch)
 
-* [做一个PDF版的书用于打印](https://thebookofshaders.com/appendix/)
+* [做一个PDF版的书用于打印](https://thebookofshaders.com/appendix/02/?lan=ch)
 
 * 用[github仓库](https://github.com/patriciogonzalezvivo/thebookofshaders)来帮助解决问题和分享代码

--- a/00/README-ch.md
+++ b/00/README-ch.md
@@ -44,7 +44,7 @@ Fragment shaders（片段着色器）可以让你控制像素在屏幕上的快�
 
 * [制作一个离线版的本书](https://thebookofshaders.com/appendix/00/?lan=ch)
 
-* [用树莓派而不是浏览器来运行书中示例](https://thebookofshaders.com/appendix/01/?lan=ch)
+* [用不带浏览器的树莓派来运行书中示例](https://thebookofshaders.com/appendix/01/?lan=ch)
 
 * [做一个PDF版的书用于打印](https://thebookofshaders.com/appendix/02/?lan=ch)
 

--- a/README-ch.md
+++ b/README-ch.md
@@ -64,6 +64,8 @@
 	* [如何离线阅读此书?](appendix/00/?lan=ch)
 	* [如何在树莓派上运行示例程序?](appendix/01/?lan=ch)
 	* [如何打印这本书](appendix/02/?lan=ch)
+	* [我怎样共创这本书](appendix/03/?lan=ch)
+    * [给那些从JS语言过来的人的介绍](appendix/04/?lan=ch) by [Nicolas Barradeau](http://www.barradeau.com/)
 
 * [example gallery](examples/?lan=ch)
 

--- a/README-ch.md
+++ b/README-ch.md
@@ -60,10 +60,10 @@
     * 环境贴图 (spherical and cube)
     * 折射和反射
 
-* [附录:](appendix/) 其他阅读本书的方式
-	* [如何离线阅读此书?](appendix/?lan=ch)
-	* [如何在树莓派上运行示例程序?](appendix/?lan=ch)
-	* [如何打印这本书](appendix/?lan=ch)
+* [附录:](appendix/?lan=ch) 其他阅读本书的方式
+	* [如何离线阅读此书?](appendix/00/?lan=ch)
+	* [如何在树莓派上运行示例程序?](appendix/01/?lan=ch)
+	* [如何打印这本书](appendix/02/?lan=ch)
 
 * [example gallery](examples/?lan=ch)
 


### PR DESCRIPTION
- Fixed links to appendix entries
- Fixed a translation in `00/README-ch.md` (previous Chinese translation means "on a Raspberry Pi **instead of** a browser" instead of "on a Raspberry Pi **without** a browser")