### PR TITLE
fix: don't use undefined behavior of smoothstep

### DIFF
--- a/05/linear.frag
+++ b/05/linear.frag
@@ -8,7 +8,7 @@ uniform float u_time;
 
 // Plot a line on Y using a value between 0.0-1.0
 float plot(vec2 st) {    
-    return smoothstep(0.02, 0.0, abs(st.y - st.x));
+    return 1.0 - smoothstep(0.0, 0.02, abs(st.y - st.x));
 }
 
 void main() {


### PR DESCRIPTION
The previous implementation calls smoothstep with edge0 < edge1. This is undefined behavior according to [the spec](https://registry.khronos.org/OpenGL-Refpages/gl4/html/smoothstep.xhtml) and the book's [glossary](https://github.com/patriciogonzalezvivo/thebookofshaders/blob/8fde956595fa90fe3cbb0239fc78c45aecb36d8f/glossary/smoothstep/README.md)

This usage was introduced in PR #245 and closes #418.