### PR TITLE
fix: parsing of shader blocks textures

### DIFF
--- a/src/parseBook.py
+++ b/src/parseBook.py
@@ -25,7 +25,7 @@ def injectShaderBlocks(_folder, _text):
     for line in lines:
         if line.find('<div class=\"codeAndCanvas\"') >= 0:
             shaderTextureResults = re.findall(
-                r'<div class=\"codeAndCanvas\" data=\".*\" data-imgs=\"(.*)\"></div>', line.rstrip())
+                r'<div class=\"codeAndCanvas\" data=\".*\" data-textures=\"(.*)\"></div>', line.rstrip())
             shaderFile = re.sub(
                 r'<div class=\"codeAndCanvas\" data=\"(.*?)\"(>| .+>)</div>', r'\1', line.rstrip())
 


### PR DESCRIPTION
### Description

Chapters 15 and 16 are using `data-textures` to specify images for their corresponding shaders, which is apparently done using js scripts during the build process.
However parseBook python script was referring to `data-imgs` when it came to feeding the textures into glslViewer.

Hence chapters 15 and 16 resulted in empty black images in the book.

`data-imgs` isn't used anywhere else in the repo, so no additional changes were required.

### Evidence
| before | after |
|---|---|
| <img width="894" height="592" alt="textures-before" src="https://github.com/user-attachments/assets/0ac3a0c7-ae3b-40c5-ae6b-97dd0240dbda" /> | <img width="1036" height="590" alt="textures-after" src="https://github.com/user-attachments/assets/a7a527d2-0d0e-4885-9265-27e9ec8cd897" /> |